### PR TITLE
Fix error: When a user belongs to 0 groups, they were being skipped. …

### DIFF
--- a/user.go
+++ b/user.go
@@ -47,6 +47,8 @@ func (r GothamDB) GetUsers() []RhizaUser {
 				lastUser = currentUser
 
 			}
+		} else {
+			userlist = append(userlist, currentUser)
 		}
 
 	}


### PR DESCRIPTION
… Now add the current user when group ids are null.
